### PR TITLE
USC-1734: Post artifact action is throwing 400 when save draft passes

### DIFF
--- a/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
+++ b/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
@@ -24,13 +24,13 @@ internal class MaximumListDepthAttributeTests
     [Test]
     public void TestsValidListDepth()
     {
-        var maxDepth = 5;
+        var maxDepth = 4;
         var document = GetDocument(maxDepth);
 
         var attribute = new MaximumListDepthAttribute(maxDepth);
 
         var depth = attribute.MaxDepth(document);
-        Assert.AreEqual(maxDepth, depth);
+        Assert.IsTrue(depth < maxDepth);
 
         var result = attribute.IsValid(document);
 

--- a/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
+++ b/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
@@ -36,7 +36,7 @@ internal class MaximumListDepthAttributeTests
         var attribute = new MaximumListDepthAttribute(maxDepth);
 
         var depth = attribute.MaxDepth(document);
-        Assert.IsTrue(depth <= maxDepth);
+        Assert.AreEqual(maxDepth, depth);
 
         var result = attribute.IsValid(document);
 

--- a/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
+++ b/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
@@ -30,7 +30,7 @@ internal class MaximumListDepthAttributeTests
         var attribute = new MaximumListDepthAttribute(maxDepth);
 
         var depth = attribute.MaxDepth(document);
-        Assert.IsTrue(depth < maxDepth);
+        Assert.IsTrue(depth <= maxDepth);
 
         var result = attribute.IsValid(document);
 
@@ -40,7 +40,7 @@ internal class MaximumListDepthAttributeTests
     [Test]
     public void TestsInvalidListDepth()
     {
-        var maxDepth = 5;
+        var maxDepth = 4;
         var document = GetDocument(maxDepth + 1);
 
         var attribute = new MaximumListDepthAttribute(maxDepth);

--- a/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
+++ b/MyBlueprint.PapierMirror.Test/MaximumListDepthAttributeTests.cs
@@ -8,8 +8,14 @@ internal class MaximumListDepthAttributeTests
 {
     private static Node GetDocument(int depth)
     {
-        Node list = new OrderedList();
-        var document = new Document { Content = new List<Node> { list } };
+        var document = new Document { Content = new List<Node> { GetList(depth) }};
+        return document;
+    }
+
+    private static Node GetList(int depth)
+    {
+        Node list;
+        var root = list = new OrderedList();
         for (var i = 0; i < depth - 1; i++)
         {
             var nestedList = new OrderedList();
@@ -18,7 +24,7 @@ internal class MaximumListDepthAttributeTests
             list = nestedList;
         }
 
-        return document;
+        return root;
     }
 
     [Test]
@@ -42,11 +48,56 @@ internal class MaximumListDepthAttributeTests
     {
         var maxDepth = 4;
         var document = GetDocument(maxDepth + 1);
-
         var attribute = new MaximumListDepthAttribute(maxDepth);
 
         var depth = attribute.MaxDepth(document);
         Assert.AreEqual(maxDepth + 1, depth);
+
+        var result = attribute.IsValid(document);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void TestValidSiblingLists()
+    {
+        const int maxDepth = 5;
+
+        var document = new Document
+        {
+            Content = new List<Node>
+            {
+                GetList(maxDepth),
+                GetList(1)
+            }
+        };
+
+        var attribute = new MaximumListDepthAttribute(maxDepth);
+        var depth = attribute.MaxDepth(document);
+
+        Assert.AreEqual(maxDepth, depth);
+
+        var result = attribute.IsValid(document);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void TestInvalidSiblingLists()
+    {
+        const int maxDepth = 5;
+
+        var document = new Document
+        {
+            Content = new List<Node>
+            {
+                GetList(maxDepth),
+                GetList(maxDepth * 2)
+            }
+        };
+
+        var attribute = new MaximumListDepthAttribute(maxDepth);
+        var depth = attribute.MaxDepth(document);
+
+        Assert.AreEqual(maxDepth * 2, depth);
 
         var result = attribute.IsValid(document);
         Assert.IsFalse(result);

--- a/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
+++ b/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
@@ -54,27 +54,12 @@ namespace MyBlueprint.PapierMirror.Validation
             {
                 if (Array.IndexOf(ListTypes, child.GetType()) >= 0)
                 {
-                    subDepth += MaxDepth(child) + 1;
-
-                    if (node.GetType() == typeof(Document))
-                    {
-                        if (subDepth > MaxNodeDepth)
-                        {
-                            MaxNodeDepth = subDepth;
-                        }
-
-                        subDepth = 0;
-                    }
+                    subDepth = Math.Max(subDepth, MaxDepth(child) + 1);
                 }
                 else
                 {
-                    subDepth += MaxDepth(child);
+                    subDepth = Math.Max(subDepth, MaxDepth(child));
                 }
-            }
-
-            if (node.GetType() == typeof(Document))
-            {
-                return MaxNodeDepth;
             }
 
             return subDepth;

--- a/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
+++ b/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
@@ -12,7 +12,6 @@ namespace MyBlueprint.PapierMirror.Validation
     {
         private int Depth { get; }
         private Type[] ListTypes { get; }
-        private int MaxNodeDepth { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MaximumListDepthAttribute"/> class.

--- a/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
+++ b/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
@@ -54,6 +54,8 @@ namespace MyBlueprint.PapierMirror.Validation
             {
                 if (Array.IndexOf(ListTypes, child.GetType()) >= 0)
                 {
+                    subDepth += MaxDepth(child) + 1;
+
                     if (node.GetType() == typeof(Document))
                     {
                         if (subDepth > MaxNodeDepth)
@@ -63,8 +65,6 @@ namespace MyBlueprint.PapierMirror.Validation
 
                         subDepth = 0;
                     }
-
-                    subDepth += MaxDepth(child) + 1;
                 }
                 else
                 {

--- a/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
+++ b/MyBlueprint.PapierMirror/Validation/MaximumListDepthAttribute.cs
@@ -12,6 +12,7 @@ namespace MyBlueprint.PapierMirror.Validation
     {
         private int Depth { get; }
         private Type[] ListTypes { get; }
+        private int MaxNodeDepth { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MaximumListDepthAttribute"/> class.
@@ -53,12 +54,27 @@ namespace MyBlueprint.PapierMirror.Validation
             {
                 if (Array.IndexOf(ListTypes, child.GetType()) >= 0)
                 {
+                    if (node.GetType() == typeof(Document))
+                    {
+                        if (subDepth > MaxNodeDepth)
+                        {
+                            MaxNodeDepth = subDepth;
+                        }
+
+                        subDepth = 0;
+                    }
+
                     subDepth += MaxDepth(child) + 1;
                 }
                 else
                 {
                     subDepth += MaxDepth(child);
                 }
+            }
+
+            if (node.GetType() == typeof(Document))
+            {
+                return MaxNodeDepth;
             }
 
             return subDepth;


### PR DESCRIPTION
USC-1734:

##Fixes:
-- Fixed an issue where the List Node Depth Validation was not resetting when the Path finding returned to the Root Node, This was causing Branch depths to be summed and failing when they were not supposed to;
-- After the change, the Validation returns the Max depth of the Longest Branch starting at the Root.

## Screenshots:
-- Unit Test Validating the Body that was failing.
https://uploads.myblueprint.org/c8a801ed_devenv_yYpr85JNa2.png